### PR TITLE
Add support for the mobileapi HTTP endpoint

### DIFF
--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/AbstractRequest.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/AbstractRequest.java
@@ -1,7 +1,13 @@
 package com.kylemsguy.tcasmobile.apiwrapper;
 
+/**
+ * Base class for all requests.
+ */
 public abstract class AbstractRequest {
 	
+	/** URL to send a POST request to. */
 	public abstract String getRequestUrl();
+	
+	/** Body for the HTTP request. */
 	public abstract String getRequestBody();
 }

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/AbstractRequest.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/AbstractRequest.java
@@ -4,10 +4,10 @@ package com.kylemsguy.tcasmobile.apiwrapper;
  * Base class for all requests.
  */
 public abstract class AbstractRequest {
-	
-	/** URL to send a POST request to. */
-	public abstract String getRequestUrl();
-	
-	/** Body for the HTTP request. */
-	public abstract String getRequestBody();
+    
+    /** URL to send a POST request to. */
+    public abstract String getRequestUrl();
+    
+    /** Body for the HTTP request. */
+    public abstract String getRequestBody();
 }

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/AbstractRequest.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/AbstractRequest.java
@@ -1,0 +1,7 @@
+package com.kylemsguy.tcasmobile.apiwrapper;
+
+public abstract class AbstractRequest {
+	
+	public abstract String getRequestUrl();
+	public abstract String getRequestBody();
+}

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/ApiEncoding.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/ApiEncoding.java
@@ -2,6 +2,9 @@ package com.kylemsguy.tcasmobile.apiwrapper;
 
 import java.io.UnsupportedEncodingException;
 
+/**
+ * Base class for all encodings.
+ */
 abstract class ApiEncoding {
 	private final String encodingVersionPrefix;
 	

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/ApiEncoding.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/ApiEncoding.java
@@ -1,0 +1,18 @@
+package com.kylemsguy.tcasmobile.apiwrapper;
+
+import java.io.UnsupportedEncodingException;
+
+abstract class ApiEncoding {
+	private final String encodingVersionPrefix;
+	
+	public ApiEncoding(String encodingVersionPrefix) {
+		this.encodingVersionPrefix = encodingVersionPrefix;
+	}
+	
+	public String getVersionPrefix() {
+		return encodingVersionPrefix;
+	}
+	
+	public abstract Object decode(String rawValue);
+	public abstract String encode(Object value);
+}

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/ApiEncoding.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/ApiEncoding.java
@@ -6,16 +6,16 @@ import java.io.UnsupportedEncodingException;
  * Base class for all encodings.
  */
 abstract class ApiEncoding {
-	private final String encodingVersionPrefix;
-	
-	public ApiEncoding(String encodingVersionPrefix) {
-		this.encodingVersionPrefix = encodingVersionPrefix;
-	}
-	
-	public String getVersionPrefix() {
-		return encodingVersionPrefix;
-	}
-	
-	public abstract Object decode(String rawValue);
-	public abstract String encode(Object value);
+    private final String encodingVersionPrefix;
+    
+    public ApiEncoding(String encodingVersionPrefix) {
+        this.encodingVersionPrefix = encodingVersionPrefix;
+    }
+    
+    public String getVersionPrefix() {
+        return encodingVersionPrefix;
+    }
+    
+    public abstract Object decode(String rawValue);
+    public abstract String encode(Object value);
 }

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/ApiEncodingV0.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/ApiEncodingV0.java
@@ -3,7 +3,26 @@ package com.kylemsguy.tcasmobile.apiwrapper;
 import java.io.UnsupportedEncodingException;
 
 /**
- * 
+ * TwoCans structured request encoding version 0. 
+ * This encoding was designed on a napkin. It is simple, compact-ish and quick.
+ * Because I fully intend to get fancier later in TwoCans3 which is coming soon, 
+ * I have given it the name v0 instead of v1.
+ *
+ * <p>Essentially, this is just a encoding for a 2D uneven array of objects.
+ * Rows are separated by commas.
+ * Items in each row are separated by vertical pipes '|'.
+ * Strings, integers, floats, booleans, and nulls are supported as items in each
+ * row. They have the following encodings:
+ * <ul>
+ * <li>Null: 'n'</li>
+ * <li>Boolean: 'B' for true, 'b' for false</li>
+ * <li>Integer: 'i' followed by a decimal representation</li>
+ * <li>Float: 'f' followed by a reasonable toString output of the value</li>
+ * <li>String: '$' followed by a hex encoded representation of the raw binary value</li>
+ * </ul>
+ *
+ * <p>TODO: fix unicode support for strings. Currently this is a raw repeater of 
+ * the ASCII values returned. Need to pass the decoded bytes through a decoding method.
  */
 final class ApiEncodingV0 extends ApiEncoding {
 	private static final char[] HEX = "0123456789ABCDEF".toCharArray();

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/ApiEncodingV0.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/ApiEncodingV0.java
@@ -13,6 +13,10 @@ final class ApiEncodingV0 extends ApiEncoding {
 	}
 	
 	public Object decode(String rawValue) {
+		return decodeImpl(rawValue);
+	}
+	
+	public Object[][] decodeImpl(String rawValue) {
 		String prefix = getVersionPrefix();
 		if (prefix.equals(rawValue.substring(0, prefix.length()))) {
 			// trim encoding prefix
@@ -23,7 +27,7 @@ final class ApiEncodingV0 extends ApiEncoding {
 		}
 		
 		String[] rows = rawValue.split(",");
-		Object[] output = new Object[rows.length];
+		Object[][] output = new Object[rows.length][];
 		for (int y = 0; y < rows.length; ++y) {
 			String[] rawRow = rows[y].split("\\|");
 			int width = rawRow.length;

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/ApiEncodingV0.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/ApiEncodingV0.java
@@ -1,0 +1,148 @@
+package com.kylemsguy.tcasmobile.apiwrapper;
+
+import java.io.UnsupportedEncodingException;
+
+/**
+ * 
+ */
+final class ApiEncodingV0 extends ApiEncoding {
+	private static final char[] HEX = "0123456789ABCDEF".toCharArray();
+	
+	public ApiEncodingV0() {
+		super("v0|");
+	}
+	
+	public Object decode(String rawValue) {
+		String prefix = getVersionPrefix();
+		if (prefix.equals(rawValue.substring(0, prefix.length()))) {
+			// trim encoding prefix
+			rawValue = rawValue.substring(prefix.length());
+		} else {
+			// TODO: custom exception
+			throw new IllegalStateException("Received an invalid encoding.");
+		}
+		
+		String[] rows = rawValue.split(",");
+		Object[] output = new Object[rows.length];
+		for (int y = 0; y < rows.length; ++y) {
+			String[] rawRow = rows[y].split("\\|");
+			int width = rawRow.length;
+			if (width == 1 && rawRow[0].length() == 0) width = 0;
+			Object[] row = new Object[width];
+			for (int x = 0; x < width; ++x) {
+				row[x] = decodeItem(rawRow[x]);
+			}
+			output[y] = row;
+		}
+		return output;
+	}
+	
+	private static Object decodeItem(String rawValue) {
+		if (rawValue.length() > 0) {
+			switch (rawValue.charAt(0)) {
+				case 'n': return null;
+				case 'B': return true;
+				case 'b': return false;
+				case 'i': return decodeInteger(rawValue.substring(1));
+				case 'f': return decodeFloat(rawValue.substring(1));
+				case '$': return decodeString(rawValue.substring(1));
+				default: break;
+			}
+		}
+		throw new IllegalStateException("Encountered unknown type.");
+	}
+	
+	private static int decodeInteger(String value) {
+		try {
+			return Integer.parseInt(value);
+		} catch (NumberFormatException nfe) {
+			throw new IllegalStateException("Encountered unrecognized value: " + value);
+		}
+	}
+	
+	private static double decodeFloat(String value) {
+		try {
+			return Double.parseDouble(value);
+		} catch (NumberFormatException nfe) {
+			throw new IllegalStateException("Encountered unrecognized value: " + value);
+		}
+	}
+	
+	private static String decodeString(String value) {
+		int length = value.length() / 2;
+		char[] output = new char[length];
+		String hex;
+		for (int i = 0; i < length; ++i) {
+			hex = value.substring(i * 2, i * 2 + 2);
+			try {
+				output[i] = (char) (Integer.parseInt(hex, 16) & 255);
+			} catch (NumberFormatException nfe) {
+				throw new IllegalStateException("Encountered unrecognized value: " + value + " | " + hex);
+			}
+		}
+		return new String(output);
+	}
+	
+	/**
+	 * Table is an array of objects or an array of array of objects.
+	 */
+	public String encode(Object value) {
+		if (!(value instanceof Object[])) value = new Object[] { value };
+		Object[] table = (Object[]) value;
+		StringBuilder output = new StringBuilder();
+		output.append("v0|");
+		boolean isSingleDimensional = !(table[0] instanceof Object[]);
+		if (isSingleDimensional) {
+			table = new Object[] { table };
+		}
+		
+		for (int i = 0; i < table.length; ++i) {
+			if (i > 0) output.append(",");
+			Object[] row = (Object[]) table[i];
+			for (int j = 0; j < row.length; ++j) {
+				Object item = row[j];
+				if (j > 0) output.append("|");
+				if (item instanceof String) encodeString((String) item, output);
+				else if (item instanceof Integer) encodeInteger((Integer) item, output);
+				else if (item instanceof Double) encodeFloat((Double) item, output);
+				else if (item instanceof Float) encodeFloat((Float) item, output);
+				else if (item instanceof Boolean) encodeBoolean((Boolean) item, output);
+				else if (item == null) encodeNull(output);
+				else throw new IllegalStateException("Invalid data type sent to encoder.");
+			}
+		}
+		
+		return output.toString();
+	}
+	
+	private static void encodeNull(StringBuilder output) {
+		output.append("n");
+	}
+	
+	private static void encodeBoolean(boolean value, StringBuilder output) {
+		output.append(value ? "B" : "b");
+	}
+	
+	private static void encodeFloat(double value, StringBuilder output) {
+		output.append("f" + value);
+	}
+	
+	private static void encodeInteger(int value, StringBuilder output) {
+		output.append("i" + value);
+	}
+	
+	private static void encodeString(String value, StringBuilder output) {
+		output.append("$");
+		byte[] bytes = null;
+		try {
+			bytes = value.getBytes("UTF-8");
+		} catch (UnsupportedEncodingException uee) {
+			throw new IllegalStateException("Universe is broken.");
+		}
+		int length = bytes.length;
+		for (int i = 0; i < length; ++i) {
+			output.append(HEX[(bytes[i] >> 4) & 15]);
+			output.append(HEX[bytes[i] & 15]);
+		}
+	}
+}

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/ApiEncodingV0.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/ApiEncodingV0.java
@@ -25,147 +25,147 @@ import java.io.UnsupportedEncodingException;
  * the ASCII values returned. Need to pass the decoded bytes through a decoding method.
  */
 final class ApiEncodingV0 extends ApiEncoding {
-	private static final char[] HEX = "0123456789ABCDEF".toCharArray();
-	
-	public ApiEncodingV0() {
-		super("v0|");
-	}
-	
-	public Object decode(String rawValue) {
-		return decodeImpl(rawValue);
-	}
-	
-	public Object[][] decodeImpl(String rawValue) {
-		String prefix = getVersionPrefix();
-		if (prefix.equals(rawValue.substring(0, prefix.length()))) {
-			// trim encoding prefix
-			rawValue = rawValue.substring(prefix.length());
-		} else {
-			// TODO: custom exception
-			throw new IllegalStateException("Received an invalid encoding.");
-		}
-		
-		String[] rows = rawValue.split(",");
-		Object[][] output = new Object[rows.length][];
-		for (int y = 0; y < rows.length; ++y) {
-			String[] rawRow = rows[y].split("\\|");
-			int width = rawRow.length;
-			if (width == 1 && rawRow[0].length() == 0) width = 0;
-			Object[] row = new Object[width];
-			for (int x = 0; x < width; ++x) {
-				row[x] = decodeItem(rawRow[x]);
-			}
-			output[y] = row;
-		}
-		return output;
-	}
-	
-	private static Object decodeItem(String rawValue) {
-		if (rawValue.length() > 0) {
-			switch (rawValue.charAt(0)) {
-				case 'n': return null;
-				case 'B': return true;
-				case 'b': return false;
-				case 'i': return decodeInteger(rawValue.substring(1));
-				case 'f': return decodeFloat(rawValue.substring(1));
-				case '$': return decodeString(rawValue.substring(1));
-				default: break;
-			}
-		}
-		throw new IllegalStateException("Encountered unknown type.");
-	}
-	
-	private static int decodeInteger(String value) {
-		try {
-			return Integer.parseInt(value);
-		} catch (NumberFormatException nfe) {
-			throw new IllegalStateException("Encountered unrecognized value: " + value);
-		}
-	}
-	
-	private static double decodeFloat(String value) {
-		try {
-			return Double.parseDouble(value);
-		} catch (NumberFormatException nfe) {
-			throw new IllegalStateException("Encountered unrecognized value: " + value);
-		}
-	}
-	
-	private static String decodeString(String value) {
-		int length = value.length() / 2;
-		char[] output = new char[length];
-		String hex;
-		for (int i = 0; i < length; ++i) {
-			hex = value.substring(i * 2, i * 2 + 2);
-			try {
-				output[i] = (char) (Integer.parseInt(hex, 16) & 255);
-			} catch (NumberFormatException nfe) {
-				throw new IllegalStateException("Encountered unrecognized value: " + value + " | " + hex);
-			}
-		}
-		return new String(output);
-	}
-	
-	/**
-	 * Table is an array of objects or an array of array of objects.
-	 */
-	public String encode(Object value) {
-		if (!(value instanceof Object[])) value = new Object[] { value };
-		Object[] table = (Object[]) value;
-		StringBuilder output = new StringBuilder();
-		output.append("v0|");
-		boolean isSingleDimensional = !(table[0] instanceof Object[]);
-		if (isSingleDimensional) {
-			table = new Object[] { table };
-		}
-		
-		for (int i = 0; i < table.length; ++i) {
-			if (i > 0) output.append(",");
-			Object[] row = (Object[]) table[i];
-			for (int j = 0; j < row.length; ++j) {
-				Object item = row[j];
-				if (j > 0) output.append("|");
-				if (item instanceof String) encodeString((String) item, output);
-				else if (item instanceof Integer) encodeInteger((Integer) item, output);
-				else if (item instanceof Double) encodeFloat((Double) item, output);
-				else if (item instanceof Float) encodeFloat((Float) item, output);
-				else if (item instanceof Boolean) encodeBoolean((Boolean) item, output);
-				else if (item == null) encodeNull(output);
-				else throw new IllegalStateException("Invalid data type sent to encoder.");
-			}
-		}
-		
-		return output.toString();
-	}
-	
-	private static void encodeNull(StringBuilder output) {
-		output.append("n");
-	}
-	
-	private static void encodeBoolean(boolean value, StringBuilder output) {
-		output.append(value ? "B" : "b");
-	}
-	
-	private static void encodeFloat(double value, StringBuilder output) {
-		output.append("f" + value);
-	}
-	
-	private static void encodeInteger(int value, StringBuilder output) {
-		output.append("i" + value);
-	}
-	
-	private static void encodeString(String value, StringBuilder output) {
-		output.append("$");
-		byte[] bytes = null;
-		try {
-			bytes = value.getBytes("UTF-8");
-		} catch (UnsupportedEncodingException uee) {
-			throw new IllegalStateException("Universe is broken.");
-		}
-		int length = bytes.length;
-		for (int i = 0; i < length; ++i) {
-			output.append(HEX[(bytes[i] >> 4) & 15]);
-			output.append(HEX[bytes[i] & 15]);
-		}
-	}
+    private static final char[] HEX = "0123456789ABCDEF".toCharArray();
+    
+    public ApiEncodingV0() {
+        super("v0|");
+    }
+    
+    public Object decode(String rawValue) {
+        return decodeImpl(rawValue);
+    }
+    
+    public Object[][] decodeImpl(String rawValue) {
+        String prefix = getVersionPrefix();
+        if (prefix.equals(rawValue.substring(0, prefix.length()))) {
+            // trim encoding prefix
+            rawValue = rawValue.substring(prefix.length());
+        } else {
+            // TODO: custom exception
+            throw new IllegalStateException("Received an invalid encoding.");
+        }
+        
+        String[] rows = rawValue.split(",");
+        Object[][] output = new Object[rows.length][];
+        for (int y = 0; y < rows.length; ++y) {
+            String[] rawRow = rows[y].split("\\|");
+            int width = rawRow.length;
+            if (width == 1 && rawRow[0].length() == 0) width = 0;
+            Object[] row = new Object[width];
+            for (int x = 0; x < width; ++x) {
+                row[x] = decodeItem(rawRow[x]);
+            }
+            output[y] = row;
+        }
+        return output;
+    }
+    
+    private static Object decodeItem(String rawValue) {
+        if (rawValue.length() > 0) {
+            switch (rawValue.charAt(0)) {
+                case 'n': return null;
+                case 'B': return true;
+                case 'b': return false;
+                case 'i': return decodeInteger(rawValue.substring(1));
+                case 'f': return decodeFloat(rawValue.substring(1));
+                case '$': return decodeString(rawValue.substring(1));
+                default: break;
+            }
+        }
+        throw new IllegalStateException("Encountered unknown type.");
+    }
+    
+    private static int decodeInteger(String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException nfe) {
+            throw new IllegalStateException("Encountered unrecognized value: " + value);
+        }
+    }
+    
+    private static double decodeFloat(String value) {
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException nfe) {
+            throw new IllegalStateException("Encountered unrecognized value: " + value);
+        }
+    }
+    
+    private static String decodeString(String value) {
+        int length = value.length() / 2;
+        char[] output = new char[length];
+        String hex;
+        for (int i = 0; i < length; ++i) {
+            hex = value.substring(i * 2, i * 2 + 2);
+            try {
+                output[i] = (char) (Integer.parseInt(hex, 16) & 255);
+            } catch (NumberFormatException nfe) {
+                throw new IllegalStateException("Encountered unrecognized value: " + value + " | " + hex);
+            }
+        }
+        return new String(output);
+    }
+    
+    /**
+     * Table is an array of objects or an array of array of objects.
+     */
+    public String encode(Object value) {
+        if (!(value instanceof Object[])) value = new Object[] { value };
+        Object[] table = (Object[]) value;
+        StringBuilder output = new StringBuilder();
+        output.append("v0|");
+        boolean isSingleDimensional = !(table[0] instanceof Object[]);
+        if (isSingleDimensional) {
+            table = new Object[] { table };
+        }
+        
+        for (int i = 0; i < table.length; ++i) {
+            if (i > 0) output.append(",");
+            Object[] row = (Object[]) table[i];
+            for (int j = 0; j < row.length; ++j) {
+                Object item = row[j];
+                if (j > 0) output.append("|");
+                if (item instanceof String) encodeString((String) item, output);
+                else if (item instanceof Integer) encodeInteger((Integer) item, output);
+                else if (item instanceof Double) encodeFloat((Double) item, output);
+                else if (item instanceof Float) encodeFloat((Float) item, output);
+                else if (item instanceof Boolean) encodeBoolean((Boolean) item, output);
+                else if (item == null) encodeNull(output);
+                else throw new IllegalStateException("Invalid data type sent to encoder.");
+            }
+        }
+        
+        return output.toString();
+    }
+    
+    private static void encodeNull(StringBuilder output) {
+        output.append("n");
+    }
+    
+    private static void encodeBoolean(boolean value, StringBuilder output) {
+        output.append(value ? "B" : "b");
+    }
+    
+    private static void encodeFloat(double value, StringBuilder output) {
+        output.append("f" + value);
+    }
+    
+    private static void encodeInteger(int value, StringBuilder output) {
+        output.append("i" + value);
+    }
+    
+    private static void encodeString(String value, StringBuilder output) {
+        output.append("$");
+        byte[] bytes = null;
+        try {
+            bytes = value.getBytes("UTF-8");
+        } catch (UnsupportedEncodingException uee) {
+            throw new IllegalStateException("Universe is broken.");
+        }
+        int length = bytes.length;
+        for (int i = 0; i < length; ++i) {
+            output.append(HEX[(bytes[i] >> 4) & 15]);
+            output.append(HEX[bytes[i] & 15]);
+        }
+    }
 }

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/Decoder.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/Decoder.java
@@ -4,24 +4,24 @@ import java.util.HashMap;
 
 /** Decodes an arbitrary server response with encoding detection. */
 final class Decoder {
-	private static final ApiEncoding V0_ENCODING = new ApiEncodingV0();
-	
-	private static final HashMap<String, ApiEncoding> ENCODING_BY_PREFIX;
-	
-	static {
-		HashMap<String, ApiEncoding> lookup = new HashMap<>();
-		lookup.put(V0_ENCODING.getVersionPrefix(), V0_ENCODING);
-		ENCODING_BY_PREFIX = lookup;
-	}
-	
-	public static Object decode(String rawValue) {
-		int pipeLocation = rawValue.indexOf("|");
-		String prefix = rawValue.substring(0, pipeLocation + 1);
-		ApiEncoding encoding = ENCODING_BY_PREFIX.get(prefix);
-		if (encoding == null) {
-			throw new IllegalStateException("Unrecognized encoding format.");
-		}
-		
-		return encoding.decode(rawValue);
-	}
+    private static final ApiEncoding V0_ENCODING = new ApiEncodingV0();
+    
+    private static final HashMap<String, ApiEncoding> ENCODING_BY_PREFIX;
+    
+    static {
+        HashMap<String, ApiEncoding> lookup = new HashMap<>();
+        lookup.put(V0_ENCODING.getVersionPrefix(), V0_ENCODING);
+        ENCODING_BY_PREFIX = lookup;
+    }
+    
+    public static Object decode(String rawValue) {
+        int pipeLocation = rawValue.indexOf("|");
+        String prefix = rawValue.substring(0, pipeLocation + 1);
+        ApiEncoding encoding = ENCODING_BY_PREFIX.get(prefix);
+        if (encoding == null) {
+            throw new IllegalStateException("Unrecognized encoding format.");
+        }
+        
+        return encoding.decode(rawValue);
+    }
 }

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/Decoder.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/Decoder.java
@@ -2,6 +2,7 @@ package com.kylemsguy.tcasmobile.apiwrapper;
 
 import java.util.HashMap;
 
+/** Decodes an arbitrary server response with encoding detection. */
 final class Decoder {
 	private static final ApiEncoding V0_ENCODING = new ApiEncodingV0();
 	

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/Decoder.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/Decoder.java
@@ -1,0 +1,26 @@
+package com.kylemsguy.tcasmobile.apiwrapper;
+
+import java.util.HashMap;
+
+final class Decoder {
+	private static final ApiEncoding V0_ENCODING = new ApiEncodingV0();
+	
+	private static final HashMap<String, ApiEncoding> ENCODING_BY_PREFIX;
+	
+	static {
+		HashMap<String, ApiEncoding> lookup = new HashMap<>();
+		lookup.put(V0_ENCODING.getVersionPrefix(), V0_ENCODING);
+		ENCODING_BY_PREFIX = lookup;
+	}
+	
+	public static Object decode(String rawValue) {
+		int pipeLocation = rawValue.indexOf("|");
+		String prefix = rawValue.substring(0, pipeLocation + 1);
+		ApiEncoding encoding = ENCODING_BY_PREFIX.get(prefix);
+		if (encoding == null) {
+			throw new IllegalStateException("Unrecognized encoding format.");
+		}
+		
+		return encoding.decode(rawValue);
+	}
+}

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/Encoder.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/Encoder.java
@@ -4,9 +4,9 @@ package com.kylemsguy.tcasmobile.apiwrapper;
  * Buffer rest of code against encoder changes.
  */
 final class Encoder {
-	private static final ApiEncoding V0_ENCODING = new ApiEncodingV0();
-	
-	public static String encode(Object value) {
-		return V0_ENCODING.encode(value);
-	}
+    private static final ApiEncoding V0_ENCODING = new ApiEncodingV0();
+    
+    public static String encode(Object value) {
+        return V0_ENCODING.encode(value);
+    }
 }

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/Encoder.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/Encoder.java
@@ -1,0 +1,12 @@
+package com.kylemsguy.tcasmobile.apiwrapper;
+
+/**
+ * Buffer rest of code against encoder changes.
+ */
+final class Encoder {
+	private static final ApiEncoding V0_ENCODING = new ApiEncodingV0();
+	
+	public static String encode(Object value) {
+		return V0_ENCODING.encode(value);
+	}
+}

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/LoginRequest.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/LoginRequest.java
@@ -1,0 +1,27 @@
+package com.kylemsguy.tcasmobile.apiwrapper;
+
+public final class LoginRequest extends AbstractRequest {
+	
+	private String username = null;
+	private String password = null;
+	
+	public LoginRequest setUsername(String username) {
+		this.username = username;
+		return this;
+	}
+	
+	public LoginRequest setPassword(String password) {
+		this.password = password;
+		return this;
+	}
+	
+	@Override
+	public String getRequestUrl() {
+		return "http://www.twocansandstring.com/mobileapi/login";
+	}
+	
+	@Override
+	public String getRequestBody() {
+		return Encoder.encode(new Object[] { username, password });
+	}
+}

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/LoginRequest.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/LoginRequest.java
@@ -1,5 +1,6 @@
 package com.kylemsguy.tcasmobile.apiwrapper;
 
+/** Builds a raw HTTP body from structured fields for a login request. */
 public final class LoginRequest extends AbstractRequest {
 	
 	private String username = null;

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/LoginRequest.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/LoginRequest.java
@@ -2,27 +2,27 @@ package com.kylemsguy.tcasmobile.apiwrapper;
 
 /** Builds a raw HTTP body from structured fields for a login request. */
 public final class LoginRequest extends AbstractRequest {
-	
-	private String username = null;
-	private String password = null;
-	
-	public LoginRequest setUsername(String username) {
-		this.username = username;
-		return this;
-	}
-	
-	public LoginRequest setPassword(String password) {
-		this.password = password;
-		return this;
-	}
-	
-	@Override
-	public String getRequestUrl() {
-		return "http://www.twocansandstring.com/mobileapi/login";
-	}
-	
-	@Override
-	public String getRequestBody() {
-		return Encoder.encode(new Object[] { username, password });
-	}
+    
+    private String username = null;
+    private String password = null;
+    
+    public LoginRequest setUsername(String username) {
+        this.username = username;
+        return this;
+    }
+    
+    public LoginRequest setPassword(String password) {
+        this.password = password;
+        return this;
+    }
+    
+    @Override
+    public String getRequestUrl() {
+        return "http://www.twocansandstring.com/mobileapi/login";
+    }
+    
+    @Override
+    public String getRequestBody() {
+        return Encoder.encode(new Object[] { username, password });
+    }
 }

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/LoginResponse.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/LoginResponse.java
@@ -4,99 +4,99 @@ package com.kylemsguy.tcasmobile.apiwrapper;
  * Converts a raw login response into structured form.
  */
 public final class LoginResponse {
-	
-	private final LoginStatus status;
-	private final int userId;
-	private final String usernameFormatted;
-	private final String usernameCanonicalized;
-	
-	public static enum LoginStatus {
-		/** Everything is fine. */
-		OK,
-		
-		/** User provided incorrect credentials. */
-		BAD_LOGIN,
-		
-		/** Server complained, but in a way client is unfamiliar with. */
-		UNKNOWN_ERROR,
-		
-		/** Server returned gobbldygook. */
-		UNRECOGNIZED_RESPONSE
-	}
-	
-	public LoginResponse(String rawResponse) {
-		Object[] response;
-		try {
-			Object gridResponse = Decoder.decode(rawResponse);
-			response = getValuesFromV0Response(gridResponse);
-		} catch (IllegalStateException e) {
-			response = null;
-		}
-		
-		LoginStatus status = LoginStatus.UNRECOGNIZED_RESPONSE;
-		int userId = 0;
-		String usernameFormatted = null;
-		String usernameCanonicalized = null;
-		
-		if (response != null) {
-			if (response.length >= 4 && "OK".equals(response[0])) {
-				if (response[1] instanceof Integer &&
-					response[2] instanceof String &&
-					response[3] instanceof String) {
-					status = LoginStatus.OK;
-					userId = (Integer) response[1];
-					usernameFormatted = (String) response[2];
-					usernameCanonicalized = (String) response[3];
-				} else {
-					status = LoginStatus.UNRECOGNIZED_RESPONSE;
-				}
-			} else if (response.length >= 2 && "ERR".equals(response[0])) {
-				if ("BAD_LOGIN".equals(response[1])) {
-					status = LoginStatus.BAD_LOGIN;
-				} else {
-					status = LoginStatus.UNKNOWN_ERROR;
-				}
-			}
-		}
-		
-		this.status = status;
-		this.userId = userId;
-		this.usernameFormatted = usernameFormatted;
-		this.usernameCanonicalized = usernameCanonicalized;
-	}
-	
-	/** Login was successful. */
-	public boolean isSuccess() {
-		return status == LoginStatus.OK;
-	}
-	
-	/** Status of the response. */
-	public LoginStatus getStatus() {
-		return status;
-	}
-	
-	/** TwoCans internal User ID# */
-	public int getUserId() {
-		return userId;
-	}
-	
-	/** Formatted string of the username. */
-	public String getUsernameFormatted() {
-		return usernameFormatted;
-	}
-	
-	/** Canonicalized form of the name. Alphanumerics only. */
-	public String getUsernameCanonicalized() {
-		return usernameCanonicalized;
-	}
-	
-	private Object[] getValuesFromV0Response(Object response) {
-		if (response instanceof Object[][]) {
-			Object[][] table = (Object[][]) response;
-			if (table.length == 1) {
-				return table[0];
-			}
-		}
-		return null;
-	}
+    
+    private final LoginStatus status;
+    private final int userId;
+    private final String usernameFormatted;
+    private final String usernameCanonicalized;
+    
+    public static enum LoginStatus {
+        /** Everything is fine. */
+        OK,
+        
+        /** User provided incorrect credentials. */
+        BAD_LOGIN,
+        
+        /** Server complained, but in a way client is unfamiliar with. */
+        UNKNOWN_ERROR,
+        
+        /** Server returned gobbldygook. */
+        UNRECOGNIZED_RESPONSE
+    }
+    
+    public LoginResponse(String rawResponse) {
+        Object[] response;
+        try {
+            Object gridResponse = Decoder.decode(rawResponse);
+            response = getValuesFromV0Response(gridResponse);
+        } catch (IllegalStateException e) {
+            response = null;
+        }
+        
+        LoginStatus status = LoginStatus.UNRECOGNIZED_RESPONSE;
+        int userId = 0;
+        String usernameFormatted = null;
+        String usernameCanonicalized = null;
+        
+        if (response != null) {
+            if (response.length >= 4 && "OK".equals(response[0])) {
+                if (response[1] instanceof Integer &&
+                    response[2] instanceof String &&
+                    response[3] instanceof String) {
+                    status = LoginStatus.OK;
+                    userId = (Integer) response[1];
+                    usernameFormatted = (String) response[2];
+                    usernameCanonicalized = (String) response[3];
+                } else {
+                    status = LoginStatus.UNRECOGNIZED_RESPONSE;
+                }
+            } else if (response.length >= 2 && "ERR".equals(response[0])) {
+                if ("BAD_LOGIN".equals(response[1])) {
+                    status = LoginStatus.BAD_LOGIN;
+                } else {
+                    status = LoginStatus.UNKNOWN_ERROR;
+                }
+            }
+        }
+        
+        this.status = status;
+        this.userId = userId;
+        this.usernameFormatted = usernameFormatted;
+        this.usernameCanonicalized = usernameCanonicalized;
+    }
+    
+    /** Login was successful. */
+    public boolean isSuccess() {
+        return status == LoginStatus.OK;
+    }
+    
+    /** Status of the response. */
+    public LoginStatus getStatus() {
+        return status;
+    }
+    
+    /** TwoCans internal User ID# */
+    public int getUserId() {
+        return userId;
+    }
+    
+    /** Formatted string of the username. */
+    public String getUsernameFormatted() {
+        return usernameFormatted;
+    }
+    
+    /** Canonicalized form of the name. Alphanumerics only. */
+    public String getUsernameCanonicalized() {
+        return usernameCanonicalized;
+    }
+    
+    private Object[] getValuesFromV0Response(Object response) {
+        if (response instanceof Object[][]) {
+            Object[][] table = (Object[][]) response;
+            if (table.length == 1) {
+                return table[0];
+            }
+        }
+        return null;
+    }
 }

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/LoginResponse.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/LoginResponse.java
@@ -1,5 +1,8 @@
 package com.kylemsguy.tcasmobile.apiwrapper;
 
+/**
+ * Converts a raw login response into structured form.
+ */
 public final class LoginResponse {
 	
 	private final LoginStatus status;
@@ -8,9 +11,16 @@ public final class LoginResponse {
 	private final String usernameCanonicalized;
 	
 	public static enum LoginStatus {
+		/** Everything is fine. */
 		OK,
+		
+		/** User provided incorrect credentials. */
 		BAD_LOGIN,
+		
+		/** Server complained, but in a way client is unfamiliar with. */
 		UNKNOWN_ERROR,
+		
+		/** Server returned gobbldygook. */
 		UNRECOGNIZED_RESPONSE
 	}
 	
@@ -55,22 +65,27 @@ public final class LoginResponse {
 		this.usernameCanonicalized = usernameCanonicalized;
 	}
 	
+	/** Login was successful. */
 	public boolean isSuccess() {
 		return status == LoginStatus.OK;
 	}
 	
+	/** Status of the response. */
 	public LoginStatus getStatus() {
 		return status;
 	}
 	
+	/** TwoCans internal User ID# */
 	public int getUserId() {
 		return userId;
 	}
 	
+	/** Formatted string of the username. */
 	public String getUsernameFormatted() {
 		return usernameFormatted;
 	}
 	
+	/** Canonicalized form of the name. Alphanumerics only. */
 	public String getUsernameCanonicalized() {
 		return usernameCanonicalized;
 	}

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/LoginResponse.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/LoginResponse.java
@@ -76,12 +76,10 @@ public final class LoginResponse {
 	}
 	
 	private Object[] getValuesFromV0Response(Object response) {
-		if (response instanceof Object[]) {
-			Object[] table = (Object[]) response;
+		if (response instanceof Object[][]) {
+			Object[][] table = (Object[][]) response;
 			if (table.length == 1) {
-				if (table[0] instanceof Object[]) {
-					return (Object[]) table[0];
-				}
+				return table[0];
 			}
 		}
 		return null;

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/LoginResponse.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/LoginResponse.java
@@ -1,0 +1,89 @@
+package com.kylemsguy.tcasmobile.apiwrapper;
+
+public final class LoginResponse {
+	
+	private final LoginStatus status;
+	private final int userId;
+	private final String usernameFormatted;
+	private final String usernameCanonicalized;
+	
+	public static enum LoginStatus {
+		OK,
+		BAD_LOGIN,
+		UNKNOWN_ERROR,
+		UNRECOGNIZED_RESPONSE
+	}
+	
+	public LoginResponse(String rawResponse) {
+		Object[] response;
+		try {
+			Object gridResponse = Decoder.decode(rawResponse);
+			response = getValuesFromV0Response(gridResponse);
+		} catch (IllegalStateException e) {
+			response = null;
+		}
+		
+		LoginStatus status = LoginStatus.UNRECOGNIZED_RESPONSE;
+		int userId = 0;
+		String usernameFormatted = null;
+		String usernameCanonicalized = null;
+		
+		if (response != null) {
+			if (response.length >= 4 && "OK".equals(response[0])) {
+				if (response[1] instanceof Integer &&
+					response[2] instanceof String &&
+					response[3] instanceof String) {
+					status = LoginStatus.OK;
+					userId = (Integer) response[1];
+					usernameFormatted = (String) response[2];
+					usernameCanonicalized = (String) response[3];
+				} else {
+					status = LoginStatus.UNRECOGNIZED_RESPONSE;
+				}
+			} else if (response.length >= 2 && "ERR".equals(response[0])) {
+				if ("BAD_LOGIN".equals(response[1])) {
+					status = LoginStatus.BAD_LOGIN;
+				} else {
+					status = LoginStatus.UNKNOWN_ERROR;
+				}
+			}
+		}
+		
+		this.status = status;
+		this.userId = userId;
+		this.usernameFormatted = usernameFormatted;
+		this.usernameCanonicalized = usernameCanonicalized;
+	}
+	
+	public boolean isSuccess() {
+		return status == LoginStatus.OK;
+	}
+	
+	public LoginStatus getStatus() {
+		return status;
+	}
+	
+	public int getUserId() {
+		return userId;
+	}
+	
+	public String getUsernameFormatted() {
+		return usernameFormatted;
+	}
+	
+	public String getUsernameCanonicalized() {
+		return usernameCanonicalized;
+	}
+	
+	private Object[] getValuesFromV0Response(Object response) {
+		if (response instanceof Object[]) {
+			Object[] table = (Object[]) response;
+			if (table.length == 1) {
+				if (table[0] instanceof Object[]) {
+					return (Object[]) table[0];
+				}
+			}
+		}
+		return null;
+	}
+}

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/UnitTests.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/UnitTests.java
@@ -1,0 +1,104 @@
+package com.kylemsguy.tcasmobile.apiwrapper;
+
+final class UnitTests {
+	/**
+	 * Tests
+	 */
+	public static void main(String[] args) {
+		testApiEncodingV0();
+		testEncodingDetection();
+		testLoginRequest();
+		testLoginResponse();
+		System.out.println("All tests pass!");
+	}
+	
+	private static void testApiEncodingV0() {
+		ApiEncoding v0Encoding = new ApiEncodingV0();
+		
+		roundTripEncodingTest(v0Encoding, 42);
+		
+		roundTripEncodingTest(v0Encoding,
+			1, 2, 3, 3.14159, "kitty", true, false, null, 0);
+		
+		roundTripEncodingTest(v0Encoding,
+			new Object[] { 1, 2, 3 },
+			new Object[] { "one", "two", "three" },
+			new Object[] { 1.0, 2.0, 3.0 },
+			new Object[] { true, false, null }
+		);
+	}
+
+	private static void testLoginRequest() {
+		LoginRequest request = new LoginRequest()
+			.setUsername("blake")
+			.setPassword("12345");
+		
+		String actual = request.getRequestBody();
+		String expected = Encoder.encode(new Object[] { "blake", "12345" });
+		assertEquals(expected, actual, "LoginRequest");
+		
+		request = new LoginRequest();
+		expected = Encoder.encode(new Object[] { null, null });
+		actual = request.getRequestBody();
+		assertEquals(expected, actual, "LoginRequest");
+	}
+	
+	private static void testLoginResponse() {
+		LoginResponse response = new LoginResponse(Encoder.encode(new Object[] { "OK", 42, "Blake", "blake" }));
+		assertEquals(LoginResponse.LoginStatus.OK, response.getStatus(), "LoginResponse");
+		assertEquals(true, response.isSuccess(), "LoginResponse");
+		assertEquals(42, response.getUserId(), "LoginResponse");
+		assertEquals("Blake", response.getUsernameFormatted(), "LoginResponse");
+		assertEquals("blake", response.getUsernameCanonicalized(), "LoginResponse");
+		
+		response = new LoginResponse("Starbucks wifi portal! Current music: 96 Degrees in the Shade");
+		assertEquals(LoginResponse.LoginStatus.UNRECOGNIZED_RESPONSE, response.getStatus(), "LoginResponse");
+		assertEquals(false, response.isSuccess(), "LoginResponse");
+		
+		response = new LoginResponse(Encoder.encode(new Object[] { "ERR", "WORLD_IS_ENDING" }));
+		assertEquals(LoginResponse.LoginStatus.UNKNOWN_ERROR, response.getStatus(), "LoginResponse");
+		assertEquals(false, response.isSuccess(), "LoginResponse");
+		
+		response = new LoginResponse(Encoder.encode(new Object[] { "ERR", "BAD_LOGIN" }));
+		assertEquals(LoginResponse.LoginStatus.BAD_LOGIN, response.getStatus(), "LoginResponse");
+		assertEquals(false, response.isSuccess(), "LoginResponse");
+		
+		response = new LoginResponse(Encoder.encode(new Object[] { "OK", "LOL, J/K, NOT OK" }));
+		assertEquals(LoginResponse.LoginStatus.UNRECOGNIZED_RESPONSE, response.getStatus(), "LoginResponse");
+		assertEquals(false, response.isSuccess(), "LoginResponse");
+	}
+	
+	private static void testEncodingDetection() {
+		Object value = "kitties";
+		String encoded1 = Encoder.encode(value);
+		Object decoded = Decoder.decode(encoded1);
+		String encoded2 = Encoder.encode(decoded);
+		if (!encoded2.equals(encoded1)) {
+			throw new IllegalStateException("Encoding detection failed.");
+		}
+		
+		// TODO: test old encoders against general Decoder when new encodings are added.
+	}
+	
+	private static String roundTripEncodingTest(ApiEncoding encoding, Object... values) {
+		String encoded = values.length == 1
+			? encoding.encode(values[0])
+			: encoding.encode(values);
+		Object decoded = encoding.decode(encoded);
+		String encodedAgain = encoding.encode(decoded);
+		if (encoded.equals(encodedAgain)) {
+			return encoded;
+		}
+		throw new IllegalStateException("TEST FAILED");
+	}
+	
+	private static void assertEquals(Object expected, Object actual, String message) {
+		if (expected == null && actual == null) return;
+		boolean error = expected == null || actual == null;
+		if (!error) {
+			error = !expected.equals(actual);
+		}
+		
+		if (error) throw new IllegalStateException(message + "\nExpected: " + expected + "\nActual: " + actual);
+	}
+}

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/UnitTests.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/UnitTests.java
@@ -1,9 +1,10 @@
 package com.kylemsguy.tcasmobile.apiwrapper;
 
+/**
+ * Unit tests for API Wrappers.
+ */
 final class UnitTests {
-	/**
-	 * Tests
-	 */
+
 	public static void main(String[] args) {
 		testApiEncodingV0();
 		testEncodingDetection();

--- a/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/UnitTests.java
+++ b/app/src/main/java/com/kylemsguy/tcasmobile/apiwrapper/UnitTests.java
@@ -5,101 +5,101 @@ package com.kylemsguy.tcasmobile.apiwrapper;
  */
 final class UnitTests {
 
-	public static void main(String[] args) {
-		testApiEncodingV0();
-		testEncodingDetection();
-		testLoginRequest();
-		testLoginResponse();
-		System.out.println("All tests pass!");
-	}
-	
-	private static void testApiEncodingV0() {
-		ApiEncoding v0Encoding = new ApiEncodingV0();
-		
-		roundTripEncodingTest(v0Encoding, 42);
-		
-		roundTripEncodingTest(v0Encoding,
-			1, 2, 3, 3.14159, "kitty", true, false, null, 0);
-		
-		roundTripEncodingTest(v0Encoding,
-			new Object[] { 1, 2, 3 },
-			new Object[] { "one", "two", "three" },
-			new Object[] { 1.0, 2.0, 3.0 },
-			new Object[] { true, false, null }
-		);
-	}
+    public static void main(String[] args) {
+        testApiEncodingV0();
+        testEncodingDetection();
+        testLoginRequest();
+        testLoginResponse();
+        System.out.println("All tests pass!");
+    }
+    
+    private static void testApiEncodingV0() {
+        ApiEncoding v0Encoding = new ApiEncodingV0();
+        
+        roundTripEncodingTest(v0Encoding, 42);
+        
+        roundTripEncodingTest(v0Encoding,
+            1, 2, 3, 3.14159, "kitty", true, false, null, 0);
+        
+        roundTripEncodingTest(v0Encoding,
+            new Object[] { 1, 2, 3 },
+            new Object[] { "one", "two", "three" },
+            new Object[] { 1.0, 2.0, 3.0 },
+            new Object[] { true, false, null }
+        );
+    }
 
-	private static void testLoginRequest() {
-		LoginRequest request = new LoginRequest()
-			.setUsername("blake")
-			.setPassword("12345");
-		
-		String actual = request.getRequestBody();
-		String expected = Encoder.encode(new Object[] { "blake", "12345" });
-		assertEquals(expected, actual, "LoginRequest");
-		
-		request = new LoginRequest();
-		expected = Encoder.encode(new Object[] { null, null });
-		actual = request.getRequestBody();
-		assertEquals(expected, actual, "LoginRequest");
-	}
-	
-	private static void testLoginResponse() {
-		LoginResponse response = new LoginResponse(Encoder.encode(new Object[] { "OK", 42, "Blake", "blake" }));
-		assertEquals(LoginResponse.LoginStatus.OK, response.getStatus(), "LoginResponse");
-		assertEquals(true, response.isSuccess(), "LoginResponse");
-		assertEquals(42, response.getUserId(), "LoginResponse");
-		assertEquals("Blake", response.getUsernameFormatted(), "LoginResponse");
-		assertEquals("blake", response.getUsernameCanonicalized(), "LoginResponse");
-		
-		response = new LoginResponse("Starbucks wifi portal! Current music: 96 Degrees in the Shade");
-		assertEquals(LoginResponse.LoginStatus.UNRECOGNIZED_RESPONSE, response.getStatus(), "LoginResponse");
-		assertEquals(false, response.isSuccess(), "LoginResponse");
-		
-		response = new LoginResponse(Encoder.encode(new Object[] { "ERR", "WORLD_IS_ENDING" }));
-		assertEquals(LoginResponse.LoginStatus.UNKNOWN_ERROR, response.getStatus(), "LoginResponse");
-		assertEquals(false, response.isSuccess(), "LoginResponse");
-		
-		response = new LoginResponse(Encoder.encode(new Object[] { "ERR", "BAD_LOGIN" }));
-		assertEquals(LoginResponse.LoginStatus.BAD_LOGIN, response.getStatus(), "LoginResponse");
-		assertEquals(false, response.isSuccess(), "LoginResponse");
-		
-		response = new LoginResponse(Encoder.encode(new Object[] { "OK", "LOL, J/K, NOT OK" }));
-		assertEquals(LoginResponse.LoginStatus.UNRECOGNIZED_RESPONSE, response.getStatus(), "LoginResponse");
-		assertEquals(false, response.isSuccess(), "LoginResponse");
-	}
-	
-	private static void testEncodingDetection() {
-		Object value = "kitties";
-		String encoded1 = Encoder.encode(value);
-		Object decoded = Decoder.decode(encoded1);
-		String encoded2 = Encoder.encode(decoded);
-		if (!encoded2.equals(encoded1)) {
-			throw new IllegalStateException("Encoding detection failed.");
-		}
-		
-		// TODO: test old encoders against general Decoder when new encodings are added.
-	}
-	
-	private static String roundTripEncodingTest(ApiEncoding encoding, Object... values) {
-		String encoded = values.length == 1
-			? encoding.encode(values[0])
-			: encoding.encode(values);
-		Object decoded = encoding.decode(encoded);
-		String encodedAgain = encoding.encode(decoded);
-		if (encoded.equals(encodedAgain)) {
-			return encoded;
-		}
-		throw new IllegalStateException("TEST FAILED");
-	}
-	
-	private static void assertEquals(Object expected, Object actual, String message) {
-		if (expected == null && actual == null) return;
-		boolean error = expected == null || actual == null;
-		if (!error) {
-			error = !expected.equals(actual);
-		}
-		
-		if (error) throw new IllegalStateException(message + "\nExpected: " + expected + "\nActual: " + actual);
-	}
+    private static void testLoginRequest() {
+        LoginRequest request = new LoginRequest()
+            .setUsername("blake")
+            .setPassword("12345");
+        
+        String actual = request.getRequestBody();
+        String expected = Encoder.encode(new Object[] { "blake", "12345" });
+        assertEquals(expected, actual, "LoginRequest");
+        
+        request = new LoginRequest();
+        expected = Encoder.encode(new Object[] { null, null });
+        actual = request.getRequestBody();
+        assertEquals(expected, actual, "LoginRequest");
+    }
+    
+    private static void testLoginResponse() {
+        LoginResponse response = new LoginResponse(Encoder.encode(new Object[] { "OK", 42, "Blake", "blake" }));
+        assertEquals(LoginResponse.LoginStatus.OK, response.getStatus(), "LoginResponse");
+        assertEquals(true, response.isSuccess(), "LoginResponse");
+        assertEquals(42, response.getUserId(), "LoginResponse");
+        assertEquals("Blake", response.getUsernameFormatted(), "LoginResponse");
+        assertEquals("blake", response.getUsernameCanonicalized(), "LoginResponse");
+        
+        response = new LoginResponse("Starbucks wifi portal! Current music: 96 Degrees in the Shade");
+        assertEquals(LoginResponse.LoginStatus.UNRECOGNIZED_RESPONSE, response.getStatus(), "LoginResponse");
+        assertEquals(false, response.isSuccess(), "LoginResponse");
+        
+        response = new LoginResponse(Encoder.encode(new Object[] { "ERR", "WORLD_IS_ENDING" }));
+        assertEquals(LoginResponse.LoginStatus.UNKNOWN_ERROR, response.getStatus(), "LoginResponse");
+        assertEquals(false, response.isSuccess(), "LoginResponse");
+        
+        response = new LoginResponse(Encoder.encode(new Object[] { "ERR", "BAD_LOGIN" }));
+        assertEquals(LoginResponse.LoginStatus.BAD_LOGIN, response.getStatus(), "LoginResponse");
+        assertEquals(false, response.isSuccess(), "LoginResponse");
+        
+        response = new LoginResponse(Encoder.encode(new Object[] { "OK", "LOL, J/K, NOT OK" }));
+        assertEquals(LoginResponse.LoginStatus.UNRECOGNIZED_RESPONSE, response.getStatus(), "LoginResponse");
+        assertEquals(false, response.isSuccess(), "LoginResponse");
+    }
+    
+    private static void testEncodingDetection() {
+        Object value = "kitties";
+        String encoded1 = Encoder.encode(value);
+        Object decoded = Decoder.decode(encoded1);
+        String encoded2 = Encoder.encode(decoded);
+        if (!encoded2.equals(encoded1)) {
+            throw new IllegalStateException("Encoding detection failed.");
+        }
+        
+        // TODO: test old encoders against general Decoder when new encodings are added.
+    }
+    
+    private static String roundTripEncodingTest(ApiEncoding encoding, Object... values) {
+        String encoded = values.length == 1
+            ? encoding.encode(values[0])
+            : encoding.encode(values);
+        Object decoded = encoding.decode(encoded);
+        String encodedAgain = encoding.encode(decoded);
+        if (encoded.equals(encodedAgain)) {
+            return encoded;
+        }
+        throw new IllegalStateException("TEST FAILED");
+    }
+    
+    private static void assertEquals(Object expected, Object actual, String message) {
+        if (expected == null && actual == null) return;
+        boolean error = expected == null || actual == null;
+        if (!error) {
+            error = !expected.equals(actual);
+        }
+        
+        if (error) throw new IllegalStateException(message + "\nExpected: " + expected + "\nActual: " + actual);
+    }
 }


### PR DESCRIPTION
This does not make HTTP requests. It does, however, serialize the body of the HTTP requests and gives you the URL to make requests to and also parses the HTTP response into structured objects. It's also written in such a way that the encoding can later be changed just in this package, while buffering the rest of your code from server side changes. 

Currently it only supports the Login endpoint, because that's the only endpoint in the TwoCans Mobile API. 
